### PR TITLE
Add routes for state utilities

### DIFF
--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -9,7 +9,7 @@ const exclude: ExcludeRule[] = [
     { pattern: /^\/auth\/login(?:\?.*)?$/ },
     { pattern: /^\/auth\/refresh$/ },
     { pattern: /^\/auth\/logout$/ },
-    { pattern: /^\/user\/[^/]+\/skin(?:\/head)?$/, methods: ['GET'] }
+    { pattern: /^\/user\/[^/]+\/skin(?:\/head)?(?:\.png)?$/, methods: ['GET'] }
 ]
 
 export default defineEventHandler(async (event) => {

--- a/server/routes/alliances/[uuid]/dissolve.post.ts
+++ b/server/routes/alliances/[uuid]/dissolve.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const allianceUuid = getRouterParam(event, 'uuid')
+    const { byPlayerUuid, stateUuid } = await readBody(event)
+    await dissolveAlliance(allianceUuid, byPlayerUuid, stateUuid)
+    return { ok: true }
+})

--- a/server/routes/alliances/[uuid]/dissolve.post.ts
+++ b/server/routes/alliances/[uuid]/dissolve.post.ts
@@ -1,3 +1,21 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['alliances'],
+    description: 'Dissolve an alliance',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'Initiator and state info',
+      required: true
+    },
+    responses: {
+      200: { description: 'Alliance dissolved' },
+      403: { description: 'Not authorized' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const allianceUuid = getRouterParam(event, 'uuid')
     const { byPlayerUuid, stateUuid } = await readBody(event)

--- a/server/routes/alliances/[uuid]/index.get.ts
+++ b/server/routes/alliances/[uuid]/index.get.ts
@@ -1,3 +1,17 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['alliances'],
+    description: 'Get alliance by UUID',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    responses: {
+      200: { description: 'Alliance info' },
+      404: { description: 'Alliance not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const allianceUuid = getRouterParam(event, 'uuid')
     return await getAllianceByUuid(allianceUuid)

--- a/server/routes/alliances/[uuid]/index.get.ts
+++ b/server/routes/alliances/[uuid]/index.get.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler(async (event) => {
+    const allianceUuid = getRouterParam(event, 'uuid')
+    return await getAllianceByUuid(allianceUuid)
+})

--- a/server/routes/alliances/[uuid]/join.post.ts
+++ b/server/routes/alliances/[uuid]/join.post.ts
@@ -1,3 +1,23 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['alliances'],
+    description: 'Send a request for a state to join an alliance',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'State and player UUIDs',
+      required: true
+    },
+    responses: {
+      200: { description: 'Join request created' },
+      400: { description: 'Already member or request pending' },
+      403: { description: 'Not authorized' },
+      404: { description: 'Alliance or state not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const allianceUuid = getRouterParam(event, 'uuid')
     const { stateUuid, playerUuid } = await readBody(event)

--- a/server/routes/alliances/[uuid]/join.post.ts
+++ b/server/routes/alliances/[uuid]/join.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const allianceUuid = getRouterParam(event, 'uuid')
+    const { stateUuid, playerUuid } = await readBody(event)
+    await requestAllianceJoin(allianceUuid, stateUuid, playerUuid)
+    return { ok: true }
+})

--- a/server/routes/alliances/[uuid]/leave.post.ts
+++ b/server/routes/alliances/[uuid]/leave.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const allianceUuid = getRouterParam(event, 'uuid')
+    const { stateUuid, playerUuid } = await readBody(event)
+    await leaveAlliance(allianceUuid, stateUuid, playerUuid)
+    return { ok: true }
+})

--- a/server/routes/alliances/[uuid]/leave.post.ts
+++ b/server/routes/alliances/[uuid]/leave.post.ts
@@ -1,3 +1,22 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['alliances'],
+    description: 'Leave an alliance',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'State and player UUIDs',
+      required: true
+    },
+    responses: {
+      200: { description: 'Left alliance' },
+      403: { description: 'Not authorized' },
+      404: { description: 'Membership not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const allianceUuid = getRouterParam(event, 'uuid')
     const { stateUuid, playerUuid } = await readBody(event)

--- a/server/routes/alliances/[uuid]/members.get.ts
+++ b/server/routes/alliances/[uuid]/members.get.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler(async (event) => {
+    const allianceUuid = getRouterParam(event, 'uuid')
+    return await listAllianceMembers(allianceUuid)
+})

--- a/server/routes/alliances/[uuid]/members.get.ts
+++ b/server/routes/alliances/[uuid]/members.get.ts
@@ -1,3 +1,16 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['alliances'],
+    description: 'List members of an alliance',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    responses: {
+      200: { description: 'Array of members' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const allianceUuid = getRouterParam(event, 'uuid')
     return await listAllianceMembers(allianceUuid)

--- a/server/routes/alliances/[uuid]/review.post.ts
+++ b/server/routes/alliances/[uuid]/review.post.ts
@@ -1,3 +1,22 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['alliances'],
+    description: 'Review alliance join request',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'Applicant and approver info',
+      required: true
+    },
+    responses: {
+      200: { description: 'Review processed' },
+      403: { description: 'Not authorized' },
+      404: { description: 'Application not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const allianceUuid = getRouterParam(event, 'uuid')
     const { applicantStateUuid, approverStateUuid, approverPlayerUuid, approve } = await readBody(event)

--- a/server/routes/alliances/[uuid]/review.post.ts
+++ b/server/routes/alliances/[uuid]/review.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const allianceUuid = getRouterParam(event, 'uuid')
+    const { applicantStateUuid, approverStateUuid, approverPlayerUuid, approve } = await readBody(event)
+    await reviewAllianceJoin(allianceUuid, applicantStateUuid, approverStateUuid, approverPlayerUuid, approve)
+    return { ok: true }
+})

--- a/server/routes/alliances/create.post.ts
+++ b/server/routes/alliances/create.post.ts
@@ -1,0 +1,5 @@
+export default defineEventHandler(async (event) => {
+    const body = await readBody(event)
+    const uuid = await createAlliance(body.creatorStateUuid, body.creatorPlayerUuid, body.name, body.description, body.purpose, body.colorHex, body.flagLink)
+    return { uuid }
+})

--- a/server/routes/alliances/create.post.ts
+++ b/server/routes/alliances/create.post.ts
@@ -1,3 +1,22 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['alliances'],
+    description: 'Create a new alliance',
+    requestBody: {
+      description: 'Alliance details',
+      required: true
+    },
+    responses: {
+      200: { description: 'Alliance created' },
+      403: { description: 'Not authorized' },
+      404: { description: 'State not found' },
+      409: { description: 'Alliance already exists' },
+      422: { description: 'Invalid input' },
+      500: { description: 'Failed to create alliance' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const body = await readBody(event)
     const uuid = await createAlliance(body.creatorStateUuid, body.creatorPlayerUuid, body.name, body.description, body.purpose, body.colorHex, body.flagLink)

--- a/server/routes/alliances/list.get.ts
+++ b/server/routes/alliances/list.get.ts
@@ -1,0 +1,13 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['alliances'],
+    description: 'List alliances'
+  }
+})
+
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+  const startAt = query.startAt ? Number(query.startAt) : 0
+  const limit = query.limit ? Number(query.limit) : 100
+  return await listAlliances(startAt, limit)
+})

--- a/server/routes/auth/login.post.ts
+++ b/server/routes/auth/login.post.ts
@@ -1,3 +1,18 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['auth'],
+    description: 'Login a user',
+    requestBody: {
+      description: 'Nickname and password',
+      required: true
+    },
+    responses: {
+      200: { description: 'Login successful' },
+      401: { description: 'Invalid password' },
+      404: { description: 'User not found' }
+    }
+  }
+})
 
 export default defineEventHandler(async (event) => {
     const { nickname, password } = await readBody(event)

--- a/server/routes/auth/logout.post.ts
+++ b/server/routes/auth/logout.post.ts
@@ -1,5 +1,15 @@
 import {H3Error} from "h3";
 
+defineRouteMeta({
+  openAPI: {
+    tags: ['auth'],
+    description: 'Logout current user',
+    responses: {
+      200: { description: 'Logout successful' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     try {
         deleteCookie(event, 'refreshToken')

--- a/server/routes/auth/refresh.post.ts
+++ b/server/routes/auth/refresh.post.ts
@@ -1,3 +1,16 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['auth'],
+    description: 'Refresh authentication tokens',
+    requestBody: { description: 'User UUID', required: true },
+    responses: {
+      200: { description: 'Tokens refreshed' },
+      401: { description: 'Invalid refresh token' },
+      404: { description: 'User not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const { uuid } = await readBody(event)
     const refreshToken = getCookie(event, 'refreshToken')

--- a/server/routes/auth/session.get.ts
+++ b/server/routes/auth/session.get.ts
@@ -1,4 +1,15 @@
 // server/auth/session.get.ts
+defineRouteMeta({
+  openAPI: {
+    tags: ['auth'],
+    description: 'Return session information',
+    responses: {
+      200: { description: 'Authenticated session' },
+      401: { description: 'Unauthenticated' },
+      404: { description: 'User not found' }
+    }
+  }
+})
 export default defineEventHandler(async (event) => {
     /* JWT уже проверен middleware ⇒ event.context.auth.uuid есть */
     const { uuid } = event.context.auth || {}

--- a/server/routes/cities/[uuid].delete.ts
+++ b/server/routes/cities/[uuid].delete.ts
@@ -1,3 +1,17 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['cities'],
+    description: 'Delete a city',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    responses: {
+      200: { description: 'City deleted' },
+      404: { description: 'City not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const uuid = getRouterParam(event, 'uuid')
     await deleteCity(uuid)

--- a/server/routes/cities/[uuid].delete.ts
+++ b/server/routes/cities/[uuid].delete.ts
@@ -1,0 +1,5 @@
+export default defineEventHandler(async (event) => {
+    const uuid = getRouterParam(event, 'uuid')
+    await deleteCity(uuid)
+    return { ok: true }
+})

--- a/server/routes/cities/[uuid].get.ts
+++ b/server/routes/cities/[uuid].get.ts
@@ -1,3 +1,16 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['cities'],
+    description: 'Get city information',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    responses: {
+      200: { description: 'City data or null if not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const uuid = getRouterParam(event, 'uuid')
     return await getCityByUuid(uuid)

--- a/server/routes/cities/[uuid].get.ts
+++ b/server/routes/cities/[uuid].get.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler(async (event) => {
+    const uuid = getRouterParam(event, 'uuid')
+    return await getCityByUuid(uuid)
+})

--- a/server/routes/cities/[uuid].put.ts
+++ b/server/routes/cities/[uuid].put.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const uuid = getRouterParam(event, 'uuid')
+    const body = await readBody(event)
+    await updateCity(uuid, body.name, body.coordinates, body.stateUuid, body.isCapital)
+    return { ok: true }
+})

--- a/server/routes/cities/[uuid].put.ts
+++ b/server/routes/cities/[uuid].put.ts
@@ -1,3 +1,22 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['cities'],
+    description: 'Update city information',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'Fields to update',
+      required: true
+    },
+    responses: {
+      200: { description: 'City updated' },
+      400: { description: 'No fields provided' },
+      500: { description: 'Failed to update city' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const uuid = getRouterParam(event, 'uuid')
     const body = await readBody(event)

--- a/server/routes/cities/[uuid]/attach-player.post.ts
+++ b/server/routes/cities/[uuid]/attach-player.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const cityUuid = getRouterParam(event, 'uuid')
+    const { playerUuid } = await readBody(event)
+    await attachPlayerToCity(playerUuid, cityUuid)
+    return { ok: true }
+})

--- a/server/routes/cities/[uuid]/attach-player.post.ts
+++ b/server/routes/cities/[uuid]/attach-player.post.ts
@@ -1,3 +1,23 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['cities'],
+    description: 'Attach a player to a city',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'Player UUID',
+      required: true
+    },
+    responses: {
+      200: { description: 'Player attached' },
+      400: { description: 'Invalid state or player' },
+      404: { description: 'City not found' },
+      500: { description: 'Failed to attach player' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const cityUuid = getRouterParam(event, 'uuid')
     const { playerUuid } = await readBody(event)

--- a/server/routes/cities/[uuid]/attach.post.ts
+++ b/server/routes/cities/[uuid]/attach.post.ts
@@ -1,3 +1,22 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['cities'],
+    description: 'Attach a city to a state',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'State UUID',
+      required: true
+    },
+    responses: {
+      200: { description: 'City attached' },
+      404: { description: 'State not found' },
+      500: { description: 'Failed to attach city' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const cityUuid = getRouterParam(event, 'uuid')
     const { stateUuid } = await readBody(event)

--- a/server/routes/cities/[uuid]/attach.post.ts
+++ b/server/routes/cities/[uuid]/attach.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const cityUuid = getRouterParam(event, 'uuid')
+    const { stateUuid } = await readBody(event)
+    await attachCityToState(cityUuid, stateUuid)
+    return { ok: true }
+})

--- a/server/routes/cities/[uuid]/detach-player.post.ts
+++ b/server/routes/cities/[uuid]/detach-player.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const cityUuid = getRouterParam(event, 'uuid')
+    const { playerUuid } = await readBody(event)
+    await detachPlayerFromCity(playerUuid)
+    return { ok: true }
+})

--- a/server/routes/cities/[uuid]/detach-player.post.ts
+++ b/server/routes/cities/[uuid]/detach-player.post.ts
@@ -1,3 +1,21 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['cities'],
+    description: 'Detach a player from a city',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'Player UUID',
+      required: true
+    },
+    responses: {
+      200: { description: 'Player detached' },
+      500: { description: 'Failed to detach player' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const cityUuid = getRouterParam(event, 'uuid')
     const { playerUuid } = await readBody(event)

--- a/server/routes/cities/[uuid]/detach.post.ts
+++ b/server/routes/cities/[uuid]/detach.post.ts
@@ -1,3 +1,18 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['cities'],
+    description: 'Detach a city from its state',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    responses: {
+      200: { description: 'City detached' },
+      400: { description: 'Cannot detach capital city' },
+      500: { description: 'Failed to detach city' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const cityUuid = getRouterParam(event, 'uuid')
     await detachCityFromState(cityUuid)

--- a/server/routes/cities/[uuid]/detach.post.ts
+++ b/server/routes/cities/[uuid]/detach.post.ts
@@ -1,0 +1,5 @@
+export default defineEventHandler(async (event) => {
+    const cityUuid = getRouterParam(event, 'uuid')
+    await detachCityFromState(cityUuid)
+    return { ok: true }
+})

--- a/server/routes/cities/[uuid]/set-capital.post.ts
+++ b/server/routes/cities/[uuid]/set-capital.post.ts
@@ -1,3 +1,18 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['cities'],
+    description: 'Mark a city as the capital of its state',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    responses: {
+      200: { description: 'Capital changed' },
+      400: { description: 'City has no state' },
+      500: { description: 'Failed to update capital' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const cityUuid = getRouterParam(event, 'uuid')
     await setCityAsCapital(cityUuid)

--- a/server/routes/cities/[uuid]/set-capital.post.ts
+++ b/server/routes/cities/[uuid]/set-capital.post.ts
@@ -1,0 +1,5 @@
+export default defineEventHandler(async (event) => {
+    const cityUuid = getRouterParam(event, 'uuid')
+    await setCityAsCapital(cityUuid)
+    return { ok: true }
+})

--- a/server/routes/cities/create.post.ts
+++ b/server/routes/cities/create.post.ts
@@ -1,3 +1,18 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['cities'],
+    description: 'Create a new city',
+    requestBody: {
+      description: 'City info',
+      required: true
+    },
+    responses: {
+      200: { description: 'City created' },
+      500: { description: 'Failed to create city' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const { name, coordinates, stateUuid, isCapital } = await readBody(event)
     await createCity(name, coordinates, stateUuid, isCapital)

--- a/server/routes/cities/create.post.ts
+++ b/server/routes/cities/create.post.ts
@@ -1,0 +1,5 @@
+export default defineEventHandler(async (event) => {
+    const { name, coordinates, stateUuid, isCapital } = await readBody(event)
+    await createCity(name, coordinates, stateUuid, isCapital)
+    return { ok: true }
+})

--- a/server/routes/cities/list.get.ts
+++ b/server/routes/cities/list.get.ts
@@ -1,0 +1,13 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['cities'],
+    description: 'List cities'
+  }
+})
+
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+  const startAt = query.startAt ? Number(query.startAt) : 0
+  const limit = query.limit ? Number(query.limit) : 100
+  return await listCities(startAt, limit)
+})

--- a/server/routes/history/[uuid]/delete.post.ts
+++ b/server/routes/history/[uuid]/delete.post.ts
@@ -1,3 +1,17 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['history'],
+    description: 'Soft-delete a history event',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: { description: 'Actor UUID', required: true },
+    responses: {
+      200: { description: 'Event deleted' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const uuid = getRouterParam(event, 'uuid')
     const { deletedByUuid } = await readBody(event)

--- a/server/routes/history/[uuid]/delete.post.ts
+++ b/server/routes/history/[uuid]/delete.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const uuid = getRouterParam(event, 'uuid')
+    const { deletedByUuid } = await readBody(event)
+    await softDeleteHistoryEvent(uuid, deletedByUuid)
+    return { ok: true }
+})

--- a/server/routes/history/[uuid]/index.get.ts
+++ b/server/routes/history/[uuid]/index.get.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler(async (event) => {
+    const uuid = getRouterParam(event, 'uuid')
+    return await getHistoryEvent(uuid)
+})

--- a/server/routes/history/[uuid]/index.get.ts
+++ b/server/routes/history/[uuid]/index.get.ts
@@ -1,3 +1,17 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['history'],
+    description: 'Get history event by UUID',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    responses: {
+      200: { description: 'History event data' },
+      404: { description: 'History event not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const uuid = getRouterParam(event, 'uuid')
     return await getHistoryEvent(uuid)

--- a/server/routes/history/[uuid]/update.post.ts
+++ b/server/routes/history/[uuid]/update.post.ts
@@ -1,3 +1,17 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['history'],
+    description: 'Update a history event',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: { description: 'Patch fields', required: true },
+    responses: {
+      200: { description: 'Event updated' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const uuid = getRouterParam(event, 'uuid')
     const body = await readBody(event)

--- a/server/routes/history/[uuid]/update.post.ts
+++ b/server/routes/history/[uuid]/update.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const uuid = getRouterParam(event, 'uuid')
+    const body = await readBody(event)
+    await updateHistoryEvent(uuid, body, body.updaterUuid)
+    return { ok: true }
+})

--- a/server/routes/history/add.post.ts
+++ b/server/routes/history/add.post.ts
@@ -1,3 +1,17 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['history'],
+    description: 'Add a history event',
+    requestBody: {
+      description: 'History event data',
+      required: true
+    },
+    responses: {
+      200: { description: 'Event created' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const body = await readBody(event)
     const uuid = await addHistoryEvent(body)

--- a/server/routes/history/add.post.ts
+++ b/server/routes/history/add.post.ts
@@ -1,0 +1,5 @@
+export default defineEventHandler(async (event) => {
+    const body = await readBody(event)
+    const uuid = await addHistoryEvent(body)
+    return { uuid }
+})

--- a/server/routes/history/count.get.ts
+++ b/server/routes/history/count.get.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler(async (event) => {
+    const query = getQuery(event)
+    return await countHistoryEvents(query as any)
+})

--- a/server/routes/history/count.get.ts
+++ b/server/routes/history/count.get.ts
@@ -1,3 +1,13 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['history'],
+    description: 'Count history events',
+    responses: {
+      200: { description: 'Number of events' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const query = getQuery(event)
     return await countHistoryEvents(query as any)

--- a/server/routes/history/list.get.ts
+++ b/server/routes/history/list.get.ts
@@ -1,0 +1,8 @@
+export default defineEventHandler(async (event) => {
+    const query = getQuery(event)
+    const startAt = query.startAt ? Number(query.startAt) : 0
+    const limit = query.limit ? Number(query.limit) : 100
+    delete query.startAt
+    delete query.limit
+    return await listHistoryEvents(query as any, startAt, limit)
+})

--- a/server/routes/history/list.get.ts
+++ b/server/routes/history/list.get.ts
@@ -1,3 +1,10 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['history'],
+    description: 'List history events'
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const query = getQuery(event)
     const startAt = query.startAt ? Number(query.startAt) : 0

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,3 +1,13 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['general'],
+    description: 'Default landing route',
+    responses: {
+      200: { description: 'Greeting message' }
+    }
+  }
+})
+
 export default defineEventHandler((event) => {
   return "Start by editing <code>server/routes/index.ts</code>.";
 });

--- a/server/routes/relations/[uuid]/review.post.ts
+++ b/server/routes/relations/[uuid]/review.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const requestUuid = getRouterParam(event, 'uuid')
+    const { reviewerStateUuid, reviewerPlayerUuid, approve } = await readBody(event)
+    await reviewRelationChange(requestUuid, reviewerStateUuid, reviewerPlayerUuid, approve)
+    return { ok: true }
+})

--- a/server/routes/relations/[uuid]/review.post.ts
+++ b/server/routes/relations/[uuid]/review.post.ts
@@ -1,3 +1,22 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['relations'],
+    description: 'Review a relation change request',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'Reviewer info and decision',
+      required: true
+    },
+    responses: {
+      200: { description: 'Request reviewed' },
+      403: { description: 'Not authorized' },
+      404: { description: 'Request not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const requestUuid = getRouterParam(event, 'uuid')
     const { reviewerStateUuid, reviewerPlayerUuid, approve } = await readBody(event)

--- a/server/routes/relations/get.get.ts
+++ b/server/routes/relations/get.get.ts
@@ -1,3 +1,17 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['relations'],
+    description: 'Get relation between two states',
+    parameters: [
+      { in: 'query', name: 'stateUuidA', required: true },
+      { in: 'query', name: 'stateUuidB', required: true }
+    ],
+    responses: {
+      200: { description: 'Relation kind or null' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const query = getQuery(event)
     const a = String(query.stateUuidA)

--- a/server/routes/relations/get.get.ts
+++ b/server/routes/relations/get.get.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const query = getQuery(event)
+    const a = String(query.stateUuidA)
+    const b = String(query.stateUuidB)
+    return await getRelation(a, b)
+})

--- a/server/routes/relations/request.post.ts
+++ b/server/routes/relations/request.post.ts
@@ -1,0 +1,5 @@
+export default defineEventHandler(async (event) => {
+    const { proposerStateUuid, targetStateUuid, requestedKind, proposerPlayerUuid } = await readBody(event)
+    const uuid = await requestRelationChange(proposerStateUuid, targetStateUuid, requestedKind, proposerPlayerUuid)
+    return { uuid }
+})

--- a/server/routes/relations/request.post.ts
+++ b/server/routes/relations/request.post.ts
@@ -1,3 +1,20 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['relations'],
+    description: 'Request a change in relations between two states',
+    requestBody: {
+      description: 'Proposer state, target state, desired kind and proposer player UUID',
+      required: true
+    },
+    responses: {
+      200: { description: 'Request created with UUID' },
+      400: { description: 'Bad request or already requested' },
+      403: { description: 'Not authorized' },
+      404: { description: 'State not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const { proposerStateUuid, targetStateUuid, requestedKind, proposerPlayerUuid } = await readBody(event)
     const uuid = await requestRelationChange(proposerStateUuid, targetStateUuid, requestedKind, proposerPlayerUuid)

--- a/server/routes/server/status.get.ts
+++ b/server/routes/server/status.get.ts
@@ -1,3 +1,14 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['server'],
+    description: 'Get current game server status',
+    responses: {
+      200: { description: 'Status info' },
+      500: { description: 'Server error' }
+    }
+  }
+})
+
 interface ServerResponse {
     status: boolean;
     count: number;

--- a/server/routes/state/[uuid]/alliances.get.ts
+++ b/server/routes/state/[uuid]/alliances.get.ts
@@ -1,3 +1,16 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['state'],
+    description: 'List alliances of a state',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    responses: {
+      200: { description: 'List of alliances' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const stateUuid = getRouterParam(event, 'uuid')
     return await listAlliancesForState(stateUuid)

--- a/server/routes/state/[uuid]/alliances.get.ts
+++ b/server/routes/state/[uuid]/alliances.get.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler(async (event) => {
+    const stateUuid = getRouterParam(event, 'uuid')
+    return await listAlliancesForState(stateUuid)
+})

--- a/server/routes/state/[uuid]/apply.post.ts
+++ b/server/routes/state/[uuid]/apply.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const stateUuid = getRouterParam(event, 'uuid')
+    const { applicantUuid } = await readBody(event)
+    await applyForMembership(stateUuid, applicantUuid)
+    return { ok: true }
+})

--- a/server/routes/state/[uuid]/apply.post.ts
+++ b/server/routes/state/[uuid]/apply.post.ts
@@ -1,3 +1,22 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['state'],
+    description: 'Apply for membership in a state',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'Applicant UUID',
+      required: true
+    },
+    responses: {
+      200: { description: 'Application submitted' },
+      400: { description: 'Already a member or dual citizenship not allowed' },
+      404: { description: 'State not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const stateUuid = getRouterParam(event, 'uuid')
     const { applicantUuid } = await readBody(event)

--- a/server/routes/state/[uuid]/approve.post.ts
+++ b/server/routes/state/[uuid]/approve.post.ts
@@ -1,3 +1,23 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['state'],
+    description: 'Approve a state',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'Administrator UUID',
+      required: true
+    },
+    responses: {
+      200: { description: 'State approved' },
+      403: { description: 'Forbidden' },
+      404: { description: 'State not found' },
+      500: { description: 'Failed to approve state' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const uuid = getRouterParam(event, 'uuid')
     const { adminUuid } = await readBody(event)

--- a/server/routes/state/[uuid]/approve.post.ts
+++ b/server/routes/state/[uuid]/approve.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const uuid = getRouterParam(event, 'uuid')
+    const { adminUuid } = await readBody(event)
+    await approveState(uuid, adminUuid)
+    return { ok: true }
+})

--- a/server/routes/state/[uuid]/cities.get.ts
+++ b/server/routes/state/[uuid]/cities.get.ts
@@ -1,3 +1,16 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['state'],
+    description: 'List cities of a state',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    responses: {
+      200: { description: 'List of cities' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const stateUuid = getRouterParam(event, 'uuid')
     return await getCitiesByStateUuid(stateUuid)

--- a/server/routes/state/[uuid]/cities.get.ts
+++ b/server/routes/state/[uuid]/cities.get.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler(async (event) => {
+    const stateUuid = getRouterParam(event, 'uuid')
+    return await getCitiesByStateUuid(stateUuid)
+})

--- a/server/routes/state/[uuid]/index.delete.ts
+++ b/server/routes/state/[uuid]/index.delete.ts
@@ -1,3 +1,23 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['state'],
+    description: 'Delete a state',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'Administrator UUID',
+      required: true
+    },
+    responses: {
+      200: { description: 'State deleted' },
+      403: { description: 'Forbidden' },
+      404: { description: 'State not found' },
+      500: { description: 'Failed to delete state' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const uuid = getRouterParam(event, 'uuid')
     const { adminUuid } = await readBody(event)

--- a/server/routes/state/[uuid]/index.delete.ts
+++ b/server/routes/state/[uuid]/index.delete.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const uuid = getRouterParam(event, 'uuid')
+    const { adminUuid } = await readBody(event)
+    await deleteState(uuid, adminUuid)
+    return { ok: true }
+})

--- a/server/routes/state/[uuid]/index.get.ts
+++ b/server/routes/state/[uuid]/index.get.ts
@@ -1,3 +1,17 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['state'],
+    description: 'Get state by UUID',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    responses: {
+      200: { description: 'State data' },
+      404: { description: 'State not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const uuid = getRouterParam(event, 'uuid')
     return await getStateByUuid(uuid)

--- a/server/routes/state/[uuid]/index.get.ts
+++ b/server/routes/state/[uuid]/index.get.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler(async (event) => {
+    const uuid = getRouterParam(event, 'uuid')
+    return await getStateByUuid(uuid)
+})

--- a/server/routes/state/[uuid]/leave.post.ts
+++ b/server/routes/state/[uuid]/leave.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const stateUuid = getRouterParam(event, 'uuid')
+    const { playerUuid } = await readBody(event)
+    await leaveState(stateUuid, playerUuid)
+    return { ok: true }
+})

--- a/server/routes/state/[uuid]/leave.post.ts
+++ b/server/routes/state/[uuid]/leave.post.ts
@@ -1,3 +1,22 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['state'],
+    description: 'Leave a state',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'Player UUID',
+      required: true
+    },
+    responses: {
+      200: { description: 'Left state' },
+      400: { description: 'Cannot leave as ruler' },
+      404: { description: 'State or player not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const stateUuid = getRouterParam(event, 'uuid')
     const { playerUuid } = await readBody(event)

--- a/server/routes/state/[uuid]/member/[playerUuid].get.ts
+++ b/server/routes/state/[uuid]/member/[playerUuid].get.ts
@@ -1,3 +1,18 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['state'],
+    description: 'Get specific state member',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true },
+      { in: 'path', name: 'playerUuid', required: true }
+    ],
+    responses: {
+      200: { description: 'Member info' },
+      404: { description: 'State or member not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const stateUuid = getRouterParam(event, 'uuid')
     const playerUuid = getRouterParam(event, 'playerUuid')

--- a/server/routes/state/[uuid]/member/[playerUuid].get.ts
+++ b/server/routes/state/[uuid]/member/[playerUuid].get.ts
@@ -1,0 +1,5 @@
+export default defineEventHandler(async (event) => {
+    const stateUuid = getRouterParam(event, 'uuid')
+    const playerUuid = getRouterParam(event, 'playerUuid')
+    return await getMember(stateUuid, playerUuid)
+})

--- a/server/routes/state/[uuid]/members-count.get.ts
+++ b/server/routes/state/[uuid]/members-count.get.ts
@@ -1,3 +1,17 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['state'],
+    description: 'Get members count for a state',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    responses: {
+      200: { description: 'Members count' },
+      404: { description: 'State not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const stateUuid = getRouterParam(event, 'uuid')
     return await getStateMembersCount(stateUuid)

--- a/server/routes/state/[uuid]/members-count.get.ts
+++ b/server/routes/state/[uuid]/members-count.get.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler(async (event) => {
+    const stateUuid = getRouterParam(event, 'uuid')
+    return await getStateMembersCount(stateUuid)
+})

--- a/server/routes/state/[uuid]/members.get.ts
+++ b/server/routes/state/[uuid]/members.get.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler(async (event) => {
+    const uuid = getRouterParam(event, 'uuid')
+    return await getStateMembers(uuid)
+})

--- a/server/routes/state/[uuid]/members.get.ts
+++ b/server/routes/state/[uuid]/members.get.ts
@@ -1,3 +1,17 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['state'],
+    description: 'Get state members',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    responses: {
+      200: { description: 'Member list' },
+      404: { description: 'No members found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const uuid = getRouterParam(event, 'uuid')
     return await getStateMembers(uuid)

--- a/server/routes/state/[uuid]/reject.post.ts
+++ b/server/routes/state/[uuid]/reject.post.ts
@@ -1,3 +1,23 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['state'],
+    description: 'Reject a state',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'Administrator UUID',
+      required: true
+    },
+    responses: {
+      200: { description: 'State rejected' },
+      403: { description: 'Forbidden' },
+      404: { description: 'State not found' },
+      500: { description: 'Failed to reject state' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const uuid = getRouterParam(event, 'uuid')
     const { adminUuid } = await readBody(event)

--- a/server/routes/state/[uuid]/reject.post.ts
+++ b/server/routes/state/[uuid]/reject.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const uuid = getRouterParam(event, 'uuid')
+    const { adminUuid } = await readBody(event)
+    await rejectState(uuid, adminUuid)
+    return { ok: true }
+})

--- a/server/routes/state/[uuid]/relation-requests.get.ts
+++ b/server/routes/state/[uuid]/relation-requests.get.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler(async (event) => {
+    const stateUuid = getRouterParam(event, 'uuid')
+    return await listPendingRelationRequests(stateUuid)
+})

--- a/server/routes/state/[uuid]/relation-requests.get.ts
+++ b/server/routes/state/[uuid]/relation-requests.get.ts
@@ -1,3 +1,16 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['state'],
+    description: 'List pending relation change requests',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    responses: {
+      200: { description: 'Pending requests list' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const stateUuid = getRouterParam(event, 'uuid')
     return await listPendingRelationRequests(stateUuid)

--- a/server/routes/state/[uuid]/relations.get.ts
+++ b/server/routes/state/[uuid]/relations.get.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler(async (event) => {
+    const stateUuid = getRouterParam(event, 'uuid')
+    return await getStateRelationsList(stateUuid)
+})

--- a/server/routes/state/[uuid]/relations.get.ts
+++ b/server/routes/state/[uuid]/relations.get.ts
@@ -1,3 +1,16 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['state'],
+    description: 'List state relations',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    responses: {
+      200: { description: 'Relations list' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const stateUuid = getRouterParam(event, 'uuid')
     return await getStateRelationsList(stateUuid)

--- a/server/routes/state/[uuid]/remove.post.ts
+++ b/server/routes/state/[uuid]/remove.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const stateUuid = getRouterParam(event, 'uuid')
+    const { uuidToRemove, uuidWhoRemoved } = await readBody(event)
+    await removeMember(stateUuid, uuidToRemove, uuidWhoRemoved)
+    return { ok: true }
+})

--- a/server/routes/state/[uuid]/remove.post.ts
+++ b/server/routes/state/[uuid]/remove.post.ts
@@ -1,3 +1,22 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['state'],
+    description: 'Remove a member from state',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'Member and initiator UUIDs',
+      required: true
+    },
+    responses: {
+      200: { description: 'Member removed' },
+      403: { description: 'Insufficient permissions' },
+      404: { description: 'State not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const stateUuid = getRouterParam(event, 'uuid')
     const { uuidToRemove, uuidWhoRemoved } = await readBody(event)

--- a/server/routes/state/[uuid]/review.post.ts
+++ b/server/routes/state/[uuid]/review.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const stateUuid = getRouterParam(event, 'uuid')
+    const { applicantUuid, reviewerUuid, approve } = await readBody(event)
+    await reviewMembershipApplication(stateUuid, applicantUuid, reviewerUuid, approve)
+    return { ok: true }
+})

--- a/server/routes/state/[uuid]/review.post.ts
+++ b/server/routes/state/[uuid]/review.post.ts
@@ -1,3 +1,22 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['state'],
+    description: 'Review membership application',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'Applicant and reviewer info',
+      required: true
+    },
+    responses: {
+      200: { description: 'Application reviewed' },
+      403: { description: 'Insufficient permissions' },
+      404: { description: 'State not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const stateUuid = getRouterParam(event, 'uuid')
     const { applicantUuid, reviewerUuid, approve } = await readBody(event)

--- a/server/routes/state/[uuid]/role.update.post.ts
+++ b/server/routes/state/[uuid]/role.update.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const stateUuid = getRouterParam(event, 'uuid')
+    const { playerUuid, updaterUuid, newRole } = await readBody(event)
+    await updateMemberRole(stateUuid, playerUuid, updaterUuid, newRole)
+    return { ok: true }
+})

--- a/server/routes/state/[uuid]/role.update.post.ts
+++ b/server/routes/state/[uuid]/role.update.post.ts
@@ -1,3 +1,23 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['state'],
+    description: 'Update role of a state member',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'Player and updater uuids with new role',
+      required: true
+    },
+    responses: {
+      200: { description: 'Role updated' },
+      400: { description: 'Invalid request or cannot change own role' },
+      403: { description: 'Insufficient permissions' },
+      404: { description: 'State or member not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const stateUuid = getRouterParam(event, 'uuid')
     const { playerUuid, updaterUuid, newRole } = await readBody(event)

--- a/server/routes/state/create.post.ts
+++ b/server/routes/state/create.post.ts
@@ -3,6 +3,13 @@ import {H3Error, MultiPartData} from "h3";
 import {fileTypeFromBuffer} from "file-type";
 import sharp from "sharp";
 
+defineRouteMeta({
+  openAPI: {
+    tags: ['state'],
+    description: 'Create a state'
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const { uuid } = event.context.auth || {}
 

--- a/server/routes/state/create.post.ts
+++ b/server/routes/state/create.post.ts
@@ -34,7 +34,7 @@ export default defineEventHandler(async (event) => {
         throw createError({ statusCode: 415, statusMessage: 'PNG only' })
     }
     try{
-        const state = declareNewState(
+        const stateUuid = await declareNewState(
             name,
             description,
             color,
@@ -48,6 +48,7 @@ export default defineEventHandler(async (event) => {
             freeEntryDesc,
             await sharp(_part.data).toBuffer()
         )
+        return { uuid: stateUuid }
     } catch (e) {
         if (e instanceof H3Error || e instanceof Error) {
             throw e;

--- a/server/routes/state/list.get.ts
+++ b/server/routes/state/list.get.ts
@@ -1,0 +1,13 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['state'],
+    description: 'List states'
+  }
+})
+
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+  const startAt = query.startAt ? Number(query.startAt) : 0
+  const limit = query.limit ? Number(query.limit) : 100
+  return await listStates(startAt, limit)
+})

--- a/server/routes/state/search.get.ts
+++ b/server/routes/state/search.get.ts
@@ -1,0 +1,12 @@
+export default defineEventHandler(async (event) => {
+    const query = getQuery(event)
+    const filters: any = {}
+    for (const [key, value] of Object.entries(query)) {
+        if (value !== undefined) filters[key] = value
+    }
+    const startAt = query.startAt ? Number(query.startAt) : undefined
+    const limit = query.limit ? Number(query.limit) : undefined
+    delete filters.startAt
+    delete filters.limit
+    return await searchStatesByFilters(filters, startAt, limit)
+})

--- a/server/routes/state/search.get.ts
+++ b/server/routes/state/search.get.ts
@@ -1,3 +1,10 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['state'],
+    description: 'Search states'
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const query = getQuery(event)
     const filters: any = {}

--- a/server/routes/user/[id]/index.get.ts
+++ b/server/routes/user/[id]/index.get.ts
@@ -1,5 +1,20 @@
 import {H3Error} from "h3";
 
+defineRouteMeta({
+  openAPI: {
+    tags: ['user'],
+    description: 'Get public user info',
+    parameters: [
+      { in: 'path', name: 'id', required: true }
+    ],
+    responses: {
+      200: { description: 'User data' },
+      400: { description: 'Invalid id' },
+      404: { description: 'User not found' }
+    }
+  }
+})
+
 /**
  * GET /user/[id]
  * Возвращает публичные поля пользователя: uuid, nickname, regDate, loginDate.

--- a/server/routes/user/[id]/skin.png.get.ts
+++ b/server/routes/user/[id]/skin.png.get.ts
@@ -1,0 +1,16 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['user'],
+    description: 'Alias for player skin PNG',
+    parameters: [
+      { in: 'path', name: 'id', required: true }
+    ],
+    responses: {
+      200: { description: 'Skin file' },
+      400: { description: 'Invalid id' },
+      404: { description: 'Skin not found' }
+    }
+  }
+})
+
+export { default } from './skin/index.get'

--- a/server/routes/user/[id]/skin/head.get.ts
+++ b/server/routes/user/[id]/skin/head.get.ts
@@ -1,6 +1,21 @@
 import { promises as fsp } from 'node:fs'
 import { join } from 'pathe'
 
+defineRouteMeta({
+  openAPI: {
+    tags: ['user'],
+    description: 'Get head of player skin as PNG',
+    parameters: [
+      { in: 'path', name: 'id', required: true }
+    ],
+    responses: {
+      200: { description: 'Head PNG' },
+      400: { description: 'Invalid id' },
+      404: { description: 'Skin not found' }
+    }
+  }
+})
+
 /**
  * GET /user/[id]/skin/head
  * Отдаёт PNG-картинку головы 1024 × 1024 (идентично /head.png).

--- a/server/routes/user/[id]/skin/head.png.get.ts
+++ b/server/routes/user/[id]/skin/head.png.get.ts
@@ -1,1 +1,16 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['user'],
+    description: 'Alias for head PNG',
+    parameters: [
+      { in: 'path', name: 'id', required: true }
+    ],
+    responses: {
+      200: { description: 'Head PNG' },
+      400: { description: 'Invalid id' },
+      404: { description: 'Skin not found' }
+    }
+  }
+})
+
 export { default } from './head.get'

--- a/server/routes/user/[id]/skin/index.delete.ts
+++ b/server/routes/user/[id]/skin/index.delete.ts
@@ -3,6 +3,23 @@ import { join } from 'pathe'
 import { useRuntimeConfig } from '#imports'
 import { useSkinSQLite } from '~/plugins/skinSqlite'
 
+defineRouteMeta({
+  openAPI: {
+    tags: ['user'],
+    description: 'Delete player skin',
+    parameters: [
+      { in: 'path', name: 'id', required: true }
+    ],
+    requestBody: { description: 'Auth credentials', required: true },
+    responses: {
+      200: { description: 'Skin deleted' },
+      400: { description: 'Invalid id' },
+      401: { description: 'Unauthorized' },
+      404: { description: 'Skin not found' }
+    }
+  }
+})
+
 /**
  * DELETE /user/[id]/skin
  * Полностью удаляет скин (файл + запись) и триггерит обновление клиента.

--- a/server/routes/user/[id]/skin/index.get.ts
+++ b/server/routes/user/[id]/skin/index.get.ts
@@ -1,5 +1,20 @@
 import { promises as fsp } from 'node:fs'
 import { join } from 'pathe'
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['user'],
+    description: 'Get player skin PNG',
+    parameters: [
+      { in: 'path', name: 'id', required: true }
+    ],
+    responses: {
+      200: { description: 'Skin file' },
+      400: { description: 'Invalid id' },
+      404: { description: 'Skin not found' }
+    }
+  }
+})
 /**
  * GET /user/[id]/skin
  * Отдаёт PNG-файл скина (идентично /skin.png).

--- a/server/routes/user/[id]/skin/index.png.get.ts
+++ b/server/routes/user/[id]/skin/index.png.get.ts
@@ -1,1 +1,16 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['user'],
+    description: 'Alias for player skin PNG',
+    parameters: [
+      { in: 'path', name: 'id', required: true }
+    ],
+    responses: {
+      200: { description: 'Skin file' },
+      400: { description: 'Invalid id' },
+      404: { description: 'Skin not found' }
+    }
+  }
+})
+
 export { default } from './index.get'

--- a/server/routes/user/[id]/skin/index.post.ts
+++ b/server/routes/user/[id]/skin/index.post.ts
@@ -1,6 +1,25 @@
 import { fileTypeFromBuffer } from 'file-type'
 import sharp from 'sharp'
 
+defineRouteMeta({
+  openAPI: {
+    tags: ['user'],
+    description: 'Upload a new player skin',
+    parameters: [
+      { in: 'path', name: 'id', required: true }
+    ],
+    requestBody: { description: 'PNG skin file', required: true },
+    responses: {
+      200: { description: 'Skin uploaded' },
+      400: { description: 'Invalid request or id' },
+      401: { description: 'Unauthorized' },
+      404: { description: 'User not found' },
+      413: { description: 'File too big' },
+      415: { description: 'PNG only' }
+    }
+  }
+})
+
 /**
  * POST /user/[id]/skin
  * Загружает новый PNG-скин, сохраняет его в SQLite и файловой системе,

--- a/server/routes/wars/[uuid]/battle/create.post.ts
+++ b/server/routes/wars/[uuid]/battle/create.post.ts
@@ -1,3 +1,22 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['wars'],
+    description: 'Create a battle for a war',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'Battle details',
+      required: true
+    },
+    responses: {
+      200: { description: 'Battle created' },
+      403: { description: 'Not authorized' },
+      404: { description: 'War not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const warUuid = getRouterParam(event, 'uuid')
     const { creatorStateUuid, creatorPlayerUuid, name, description, type, startDate } = await readBody(event)

--- a/server/routes/wars/[uuid]/battle/create.post.ts
+++ b/server/routes/wars/[uuid]/battle/create.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const warUuid = getRouterParam(event, 'uuid')
+    const { creatorStateUuid, creatorPlayerUuid, name, description, type, startDate } = await readBody(event)
+    const uuid = await createBattle(warUuid, creatorStateUuid, creatorPlayerUuid, name, description, type, startDate)
+    return { uuid }
+})

--- a/server/routes/wars/[uuid]/battles.get.ts
+++ b/server/routes/wars/[uuid]/battles.get.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler(async (event) => {
+    const warUuid = getRouterParam(event, 'uuid')
+    return await listWarBattles(warUuid)
+})

--- a/server/routes/wars/[uuid]/battles.get.ts
+++ b/server/routes/wars/[uuid]/battles.get.ts
@@ -1,3 +1,17 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['wars'],
+    description: 'List battles for a war',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    responses: {
+      200: { description: 'Battles list' },
+      404: { description: 'War not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const warUuid = getRouterParam(event, 'uuid')
     return await listWarBattles(warUuid)

--- a/server/routes/wars/[uuid]/finish.post.ts
+++ b/server/routes/wars/[uuid]/finish.post.ts
@@ -1,3 +1,23 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['wars'],
+    description: 'Finish a war',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'Result text, result action and administrator UUID',
+      required: true
+    },
+    responses: {
+      200: { description: 'War finished' },
+      400: { description: 'War not active' },
+      403: { description: 'Not authorized' },
+      404: { description: 'War not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const warUuid = getRouterParam(event, 'uuid')
     const { result, resultAction, adminUuid } = await readBody(event)

--- a/server/routes/wars/[uuid]/finish.post.ts
+++ b/server/routes/wars/[uuid]/finish.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const warUuid = getRouterParam(event, 'uuid')
+    const { result, resultAction, adminUuid } = await readBody(event)
+    await finishWar(warUuid, result, resultAction, adminUuid)
+    return { ok: true }
+})

--- a/server/routes/wars/[uuid]/index.get.ts
+++ b/server/routes/wars/[uuid]/index.get.ts
@@ -1,3 +1,17 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['wars'],
+    description: 'Get war details',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    responses: {
+      200: { description: 'War information' },
+      404: { description: 'War not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const warUuid = getRouterParam(event, 'uuid')
     return await getWarByUuid(warUuid)

--- a/server/routes/wars/[uuid]/index.get.ts
+++ b/server/routes/wars/[uuid]/index.get.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler(async (event) => {
+    const warUuid = getRouterParam(event, 'uuid')
+    return await getWarByUuid(warUuid)
+})

--- a/server/routes/wars/[uuid]/respond.post.ts
+++ b/server/routes/wars/[uuid]/respond.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const warUuid = getRouterParam(event, 'uuid')
+    const { defenderStateUuid, defenderPlayerUuid, accept } = await readBody(event)
+    await respondWarDeclaration(warUuid, defenderStateUuid, defenderPlayerUuid, accept)
+    return { ok: true }
+})

--- a/server/routes/wars/[uuid]/respond.post.ts
+++ b/server/routes/wars/[uuid]/respond.post.ts
@@ -1,3 +1,23 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['wars'],
+    description: 'Respond to a war declaration',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'Defender info and decision',
+      required: true
+    },
+    responses: {
+      200: { description: 'Decision recorded' },
+      400: { description: 'War already processed' },
+      403: { description: 'Not authorized' },
+      404: { description: 'Defender not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const warUuid = getRouterParam(event, 'uuid')
     const { defenderStateUuid, defenderPlayerUuid, accept } = await readBody(event)

--- a/server/routes/wars/[uuid]/schedule.post.ts
+++ b/server/routes/wars/[uuid]/schedule.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const warUuid = getRouterParam(event, 'uuid')
+    const { adminUuid } = await readBody(event)
+    await scheduleWar(warUuid, adminUuid)
+    return { ok: true }
+})

--- a/server/routes/wars/[uuid]/schedule.post.ts
+++ b/server/routes/wars/[uuid]/schedule.post.ts
@@ -1,3 +1,20 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['wars'],
+    description: 'Schedule an accepted war',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: { description: 'Administrator UUID', required: true },
+    responses: {
+      200: { description: 'War scheduled' },
+      400: { description: 'War must be accepted' },
+      403: { description: 'Not authorized' },
+      404: { description: 'War not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const warUuid = getRouterParam(event, 'uuid')
     const { adminUuid } = await readBody(event)

--- a/server/routes/wars/[uuid]/start.post.ts
+++ b/server/routes/wars/[uuid]/start.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const warUuid = getRouterParam(event, 'uuid')
+    const { adminUuid } = await readBody(event)
+    await startWar(warUuid, adminUuid)
+    return { ok: true }
+})

--- a/server/routes/wars/[uuid]/start.post.ts
+++ b/server/routes/wars/[uuid]/start.post.ts
@@ -1,3 +1,23 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['wars'],
+    description: 'Start a war',
+    parameters: [
+      { in: 'path', name: 'uuid', required: true }
+    ],
+    requestBody: {
+      description: 'Administrator UUID',
+      required: true
+    },
+    responses: {
+      200: { description: 'War started' },
+      400: { description: 'War not scheduled' },
+      403: { description: 'Not authorized' },
+      404: { description: 'War not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const warUuid = getRouterParam(event, 'uuid')
     const { adminUuid } = await readBody(event)

--- a/server/routes/wars/battle/[battleUuid]/update.post.ts
+++ b/server/routes/wars/battle/[battleUuid]/update.post.ts
@@ -1,3 +1,22 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['wars'],
+    description: 'Update battle status',
+    parameters: [
+      { in: 'path', name: 'battleUuid', required: true }
+    ],
+    requestBody: {
+      description: 'Status update information',
+      required: true
+    },
+    responses: {
+      200: { description: 'Status updated' },
+      403: { description: 'Not authorized' },
+      404: { description: 'Battle not found' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const battleUuid = getRouterParam(event, 'battleUuid')
     const { status, updaterUuid, result, endDate } = await readBody(event)

--- a/server/routes/wars/battle/[battleUuid]/update.post.ts
+++ b/server/routes/wars/battle/[battleUuid]/update.post.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+    const battleUuid = getRouterParam(event, 'battleUuid')
+    const { status, updaterUuid, result, endDate } = await readBody(event)
+    await updateBattleStatus(battleUuid, status, updaterUuid, result, endDate)
+    return { ok: true }
+})

--- a/server/routes/wars/declare.post.ts
+++ b/server/routes/wars/declare.post.ts
@@ -1,3 +1,20 @@
+defineRouteMeta({
+  openAPI: {
+    tags: ['wars'],
+    description: 'Declare a new war',
+    requestBody: {
+      description: 'War details',
+      required: true
+    },
+    responses: {
+      200: { description: 'War declared' },
+      403: { description: 'Not authorized' },
+      404: { description: 'State not found' },
+      500: { description: 'Failed to declare war' }
+    }
+  }
+})
+
 export default defineEventHandler(async (event) => {
     const body = await readBody(event)
     const uuid = await declareWar(body.attackerStateUuid, body.defenderStateUuid, body.attackerPlayerUuid, body.name, body.reason, body.victoryCondition)

--- a/server/routes/wars/declare.post.ts
+++ b/server/routes/wars/declare.post.ts
@@ -1,0 +1,5 @@
+export default defineEventHandler(async (event) => {
+    const body = await readBody(event)
+    const uuid = await declareWar(body.attackerStateUuid, body.defenderStateUuid, body.attackerPlayerUuid, body.name, body.reason, body.victoryCondition)
+    return { uuid }
+})

--- a/server/utils/states/cities.utils.ts
+++ b/server/utils/states/cities.utils.ts
@@ -261,3 +261,13 @@ export async function detachPlayerFromCity(playerUuid: string): Promise<void> {
     }
 }
 
+export async function listCities(startAt = 0, limit = 100): Promise<ICity[]> {
+    const db = useDatabase('states');
+    const stmt = db.prepare('SELECT * FROM cities ORDER BY created DESC LIMIT ? OFFSET ?');
+    const rows = await stmt.all(limit, startAt) as ICity[];
+    return rows.map(city => ({
+        ...city,
+        is_capital: Boolean(city.is_capital)
+    }));
+}
+

--- a/server/utils/states/diplomacy.utils.ts
+++ b/server/utils/states/diplomacy.utils.ts
@@ -432,6 +432,15 @@ export async function listAlliancesForState(
         .all(stateUuid, AllianceStatus.ACTIVE)) as IAlliance[]
 }
 
+export async function listAlliances(
+    startAt = 0,
+    limit = 100
+): Promise<IAlliance[]> {
+    return (await db()
+        .prepare('SELECT * FROM alliances WHERE status = ? ORDER BY created DESC LIMIT ? OFFSET ?')
+        .all(AllianceStatus.ACTIVE, limit, startAt)) as IAlliance[]
+}
+
 /* ───────────────── 2. ДВУСТОРОННИЕ ОТНОШЕНИЯ ────────────────── */
 
 /**

--- a/server/utils/states/state.utils.ts
+++ b/server/utils/states/state.utils.ts
@@ -365,6 +365,10 @@ export async function searchStatesByFilters(
     return rows
 }
 
+export async function listStates(startAt = 0, limit = 100): Promise<IState[]> {
+    return searchStatesByFilters({}, startAt, limit)
+}
+
 
 
 


### PR DESCRIPTION
## Summary
- implement missing API routes for states, cities, alliances, diplomacy, wars and history utilities
- return created state UUID in `create.post` route

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68437605fd188323aeace99212233fd4