### PR TITLE
Add state warrant and order utilities and routes

### DIFF
--- a/server/routes/order/[uuid]/delete.post.ts
+++ b/server/routes/order/[uuid]/delete.post.ts
@@ -1,0 +1,18 @@
+import { deleteOrder } from '~/utils/states/orders.utils'
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['order'],
+    description: 'Delete an order',
+    parameters: [ { in: 'path', name: 'uuid', required: true } ],
+    requestBody: { description: 'Requester UUID', required: true },
+    responses: { 200: { description: 'Deleted', content: { 'application/json': { schema: { type: 'object', properties: { ok: { type: 'boolean' } } } } } } }
+  }
+})
+
+export default defineEventHandler(async (event) => {
+  const uuid = getRouterParam(event, 'uuid')
+  const body = await readBody(event)
+  await deleteOrder(uuid, body.requesterUuid)
+  return { ok: true }
+})

--- a/server/routes/order/[uuid]/index.get.ts
+++ b/server/routes/order/[uuid]/index.get.ts
@@ -1,0 +1,18 @@
+import { getOrder } from '~/utils/states/orders.utils'
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['order'],
+    description: 'Get order by UUID',
+    parameters: [ { in: 'path', name: 'uuid', required: true } ],
+    responses: {
+      200: { description: 'Order data', content: { 'application/json': { schema: { $ref: '#/components/schemas/IStateOrder' } } } },
+      404: { description: 'Order not found' }
+    }
+  }
+})
+
+export default defineEventHandler(async (event) => {
+  const uuid = getRouterParam(event, 'uuid')
+  return await getOrder(uuid)
+})

--- a/server/routes/order/[uuid]/update.post.ts
+++ b/server/routes/order/[uuid]/update.post.ts
@@ -1,0 +1,18 @@
+import { updateOrder } from '~/utils/states/orders.utils'
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['order'],
+    description: 'Update an order',
+    parameters: [ { in: 'path', name: 'uuid', required: true } ],
+    requestBody: { description: 'Patch fields', required: true },
+    responses: { 200: { description: 'Updated', content: { 'application/json': { schema: { type: 'object', properties: { ok: { type: 'boolean' } } } } } } }
+  }
+})
+
+export default defineEventHandler(async (event) => {
+  const uuid = getRouterParam(event, 'uuid')
+  const body = await readBody(event)
+  await updateOrder(uuid, body, body.updaterUuid)
+  return { ok: true }
+})

--- a/server/routes/order/create.post.ts
+++ b/server/routes/order/create.post.ts
@@ -1,0 +1,41 @@
+import { createOrder } from '~/utils/states/orders.utils'
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['order'],
+    description: 'Create a state order',
+    parameters: [ { in: 'header', name: 'Authorization', required: true, schema: { type: 'string' } } ],
+    requestBody: {
+      description: 'Order data',
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              stateUuid: { type: 'string' },
+              title: { type: 'string' },
+              text: { type: 'string' },
+              issuedByPlayerUuid: { type: 'string' },
+              importance: { type: 'string' },
+              expiresAt: { type: 'number', nullable: true }
+            },
+            required: ['stateUuid', 'title', 'text', 'issuedByPlayerUuid']
+          }
+        }
+      }
+    },
+    responses: {
+      200: {
+        description: 'Order created',
+        content: { 'application/json': { schema: { type: 'object', properties: { uuid: { type: 'string' } } } } }
+      }
+    }
+  }
+})
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+  const uuid = await createOrder(body.stateUuid, body.title, body.text, body.issuedByPlayerUuid, body.importance, body.expiresAt)
+  return { uuid }
+})

--- a/server/routes/warrant/[uuid]/delete.post.ts
+++ b/server/routes/warrant/[uuid]/delete.post.ts
@@ -1,0 +1,18 @@
+import { deleteWarrant } from '~/utils/states/orders.utils'
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['warrant'],
+    description: 'Delete a warrant',
+    parameters: [ { in: 'path', name: 'uuid', required: true } ],
+    requestBody: { description: 'Requester UUID', required: true },
+    responses: { 200: { description: 'Deleted', content: { 'application/json': { schema: { type: 'object', properties: { ok: { type: 'boolean' } } } } } } }
+  }
+})
+
+export default defineEventHandler(async (event) => {
+  const uuid = getRouterParam(event, 'uuid')
+  const body = await readBody(event)
+  await deleteWarrant(uuid, body.requesterUuid)
+  return { ok: true }
+})

--- a/server/routes/warrant/[uuid]/index.get.ts
+++ b/server/routes/warrant/[uuid]/index.get.ts
@@ -1,0 +1,18 @@
+import { getWarrant } from '~/utils/states/orders.utils'
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['warrant'],
+    description: 'Get warrant by UUID',
+    parameters: [ { in: 'path', name: 'uuid', required: true } ],
+    responses: {
+      200: { description: 'Warrant data', content: { 'application/json': { schema: { $ref: '#/components/schemas/IStateWarrant' } } } },
+      404: { description: 'Warrant not found' }
+    }
+  }
+})
+
+export default defineEventHandler(async (event) => {
+  const uuid = getRouterParam(event, 'uuid')
+  return await getWarrant(uuid)
+})

--- a/server/routes/warrant/[uuid]/update.post.ts
+++ b/server/routes/warrant/[uuid]/update.post.ts
@@ -1,0 +1,18 @@
+import { updateWarrant } from '~/utils/states/orders.utils'
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['warrant'],
+    description: 'Update a warrant',
+    parameters: [ { in: 'path', name: 'uuid', required: true } ],
+    requestBody: { description: 'Patch fields', required: true },
+    responses: { 200: { description: 'Updated', content: { 'application/json': { schema: { type: 'object', properties: { ok: { type: 'boolean' } } } } } } }
+  }
+})
+
+export default defineEventHandler(async (event) => {
+  const uuid = getRouterParam(event, 'uuid')
+  const body = await readBody(event)
+  await updateWarrant(uuid, body, body.updaterUuid)
+  return { ok: true }
+})

--- a/server/routes/warrant/create.post.ts
+++ b/server/routes/warrant/create.post.ts
@@ -1,0 +1,44 @@
+import { createWarrant } from "~/utils/states/orders.utils"
+defineRouteMeta({
+  openAPI: {
+    tags: ['warrant'],
+    description: 'Create a state warrant',
+    parameters: [
+      { in: 'header', name: 'Authorization', required: true, schema: { type: 'string' } }
+    ],
+    requestBody: {
+      description: 'Warrant data',
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              stateUuid: { type: 'string' },
+              affectedPlayerUuid: { type: 'string' },
+              reason: { type: 'string' },
+              issuedByPlayerUuid: { type: 'string' }
+            },
+            required: ['stateUuid', 'affectedPlayerUuid', 'reason', 'issuedByPlayerUuid']
+          }
+        }
+      }
+    },
+    responses: {
+      200: {
+        description: 'Warrant created',
+        content: {
+          'application/json': {
+            schema: { type: 'object', properties: { uuid: { type: 'string' } } }
+          }
+        }
+      }
+    }
+  }
+})
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+  const uuid = await createWarrant(body.stateUuid, body.affectedPlayerUuid, body.reason, body.issuedByPlayerUuid)
+  return { uuid }
+})

--- a/server/routes/warrant/list.get.ts
+++ b/server/routes/warrant/list.get.ts
@@ -1,9 +1,9 @@
-import { listOrdersByState } from '~/utils/states/orders.utils'
+import { listWarrantsByState } from '~/utils/states/orders.utils'
 
 defineRouteMeta({
   openAPI: {
-    tags: ['order'],
-    description: 'List orders for a state',
+    tags: ['warrant'],
+    description: 'List warrants for a state',
     parameters: [
       { in: 'query', name: 'stateUuid', required: true, schema: { type: 'string' } },
       { in: 'query', name: 'startAt', required: false, schema: { type: 'number' } },
@@ -11,8 +11,8 @@ defineRouteMeta({
     ],
     responses: {
       200: {
-        description: 'Array of orders',
-        content: { 'application/json': { schema: { type: 'array', items: { $ref: '#/components/schemas/IStateOrder' } } } }
+        description: 'Array of warrants',
+        content: { 'application/json': { schema: { type: 'array', items: { $ref: '#/components/schemas/IStateWarrant' } } } }
       }
     }
   }
@@ -22,5 +22,5 @@ export default defineEventHandler(async (event) => {
   const query = getQuery(event)
   const start = query.startAt ? Number(query.startAt) : 0
   const limit = query.limit ? Number(query.limit) : 100
-  return await listOrdersByState(String(query.stateUuid), start, limit)
+  return await listWarrantsByState(String(query.stateUuid), start, limit)
 })

--- a/server/utils/states/orders.utils.ts
+++ b/server/utils/states/orders.utils.ts
@@ -1,0 +1,208 @@
+import { v4 as uuidv4 } from 'uuid'
+import { IStateWarrant, IStateOrder, RolesInState } from '~/interfaces/state/state.types'
+import { isRoleHigherOrEqual } from '~/utils/states/citizenship.utils'
+
+const db = () => useDatabase('states')
+
+/* -------------------- Warrants -------------------- */
+
+export async function createWarrant(
+    stateUuid: string,
+    affectedPlayerUuid: string,
+    reason: string,
+    issuedByPlayerUuid: string
+): Promise<string> {
+    if (!await isRoleHigherOrEqual(stateUuid, issuedByPlayerUuid, RolesInState.OFFICER)) {
+        throw createError({
+            statusCode: 403,
+            statusMessage: 'Not authorized',
+            data: { statusMessageRu: 'Недостаточно прав для выдачи ордера' }
+        })
+    }
+
+    const uuid = uuidv4()
+    const now = Date.now()
+    const stmt = db().prepare(`
+        INSERT INTO state_warrants (
+            uuid, created, updated,
+            state_uuid, affected_player_uuid,
+            reason, issued_by_player_uuid,
+            actions_taken_by_admins,
+            actions_by_admins_details,
+            actions_taken_by_state,
+            actions_by_state_details
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, NULL, 0, NULL)
+    `)
+    const res = await stmt.run(
+        uuid,
+        now,
+        now,
+        stateUuid,
+        affectedPlayerUuid,
+        reason,
+        issuedByPlayerUuid
+    )
+    if (!res.success) {
+        throw createError({
+            statusCode: 500,
+            statusMessage: 'Failed to create warrant',
+            data: { statusMessageRu: 'Не удалось создать ордер' }
+        })
+    }
+    return uuid
+}
+
+export async function getWarrant(uuid: string): Promise<IStateWarrant> {
+    const row = await db().prepare('SELECT * FROM state_warrants WHERE uuid = ?').get(uuid) as IStateWarrant | undefined
+    if (!row) {
+        throw createError({
+            statusCode: 404,
+            statusMessage: 'Warrant not found',
+            data: { statusMessageRu: 'Ордер не найден' }
+        })
+    }
+    return row
+}
+
+export async function listWarrantsByState(stateUuid: string, startAt = 0, limit = 100): Promise<IStateWarrant[]> {
+    const rows = await db().prepare(
+        'SELECT * FROM state_warrants WHERE state_uuid = ? ORDER BY created DESC LIMIT ? OFFSET ?'
+    ).all(stateUuid, limit, startAt) as IStateWarrant[]
+    return rows
+}
+
+export async function updateWarrant(uuid: string, patch: Partial<IStateWarrant>, updaterUuid: string): Promise<void> {
+    const warrant = await getWarrant(uuid)
+    if (!await isRoleHigherOrEqual(warrant.state_uuid, updaterUuid, RolesInState.OFFICER)) {
+        throw createError({
+            statusCode: 403,
+            statusMessage: 'Not authorized',
+            data: { statusMessageRu: 'Недостаточно прав для изменения ордера' }
+        })
+    }
+    const cols: string[] = []
+    const params: any[] = []
+    for (const [key, val] of Object.entries(patch)) {
+        if (val === undefined) continue
+        cols.push(`${key} = ?`)
+        params.push(val)
+    }
+    if (!cols.length) return
+    cols.push('updated = ?')
+    params.push(Date.now())
+    params.push(uuid)
+    const sql = `UPDATE state_warrants SET ${cols.join(', ')} WHERE uuid = ?`
+    const res = await db().prepare(sql).run(...params)
+    if (!res.success) {
+        throw createError({ statusCode: 500, statusMessage: 'Failed to update warrant' })
+    }
+}
+
+export async function deleteWarrant(uuid: string, requesterUuid: string): Promise<void> {
+    const warrant = await getWarrant(uuid)
+    if (!await isRoleHigherOrEqual(warrant.state_uuid, requesterUuid, RolesInState.OFFICER)) {
+        throw createError({
+            statusCode: 403,
+            statusMessage: 'Not authorized',
+            data: { statusMessageRu: 'Недостаточно прав для удаления ордера' }
+        })
+    }
+    const res = await db().prepare('DELETE FROM state_warrants WHERE uuid = ?').run(uuid)
+    if (!res.success) {
+        throw createError({ statusCode: 500, statusMessage: 'Failed to delete warrant' })
+    }
+}
+
+/* -------------------- Orders -------------------- */
+
+export async function createOrder(
+    stateUuid: string,
+    title: string,
+    text: string,
+    issuedByPlayerUuid: string,
+    importance: 'pinned' | 'high' | 'medium' | 'low' = 'low',
+    expiresAt: number | null = null
+): Promise<string> {
+    if (!await isRoleHigherOrEqual(stateUuid, issuedByPlayerUuid, RolesInState.MINISTER)) {
+        throw createError({
+            statusCode: 403,
+            statusMessage: 'Not authorized',
+            data: { statusMessageRu: 'Недостаточно прав для издания указа' }
+        })
+    }
+    const uuid = uuidv4()
+    const now = Date.now()
+    const stmt = db().prepare(`
+        INSERT INTO state_orders (
+            uuid, created, updated,
+            state_uuid, title, text,
+            published_at, issued_by_player_uuid,
+            importance, is_active, expires_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?)
+    `)
+    const res = await stmt.run(
+        uuid,
+        now,
+        now,
+        stateUuid,
+        title,
+        text,
+        now,
+        issuedByPlayerUuid,
+        importance,
+        expiresAt
+    )
+    if (!res.success) {
+        throw createError({ statusCode: 500, statusMessage: 'Failed to create order', data: { statusMessageRu: 'Не удалось создать указ' } })
+    }
+    return uuid
+}
+
+export async function getOrder(uuid: string): Promise<IStateOrder> {
+    const row = await db().prepare('SELECT * FROM state_orders WHERE uuid = ?').get(uuid) as IStateOrder | undefined
+    if (!row) {
+        throw createError({ statusCode: 404, statusMessage: 'Order not found', data: { statusMessageRu: 'Указ не найден' } })
+    }
+    return row
+}
+
+export async function listOrdersByState(stateUuid: string, startAt = 0, limit = 100): Promise<IStateOrder[]> {
+    const rows = await db().prepare(
+        'SELECT * FROM state_orders WHERE state_uuid = ? ORDER BY published_at DESC LIMIT ? OFFSET ?'
+    ).all(stateUuid, limit, startAt) as IStateOrder[]
+    return rows
+}
+
+export async function updateOrder(uuid: string, patch: Partial<IStateOrder>, updaterUuid: string): Promise<void> {
+    const order = await getOrder(uuid)
+    if (!await isRoleHigherOrEqual(order.state_uuid, updaterUuid, RolesInState.MINISTER)) {
+        throw createError({ statusCode: 403, statusMessage: 'Not authorized', data: { statusMessageRu: 'Недостаточно прав для изменения указа' } })
+    }
+    const cols: string[] = []
+    const params: any[] = []
+    for (const [key, val] of Object.entries(patch)) {
+        if (val === undefined) continue
+        cols.push(`${key} = ?`)
+        params.push(val)
+    }
+    if (!cols.length) return
+    cols.push('updated = ?')
+    params.push(Date.now())
+    params.push(uuid)
+    const sql = `UPDATE state_orders SET ${cols.join(', ')} WHERE uuid = ?`
+    const res = await db().prepare(sql).run(...params)
+    if (!res.success) {
+        throw createError({ statusCode: 500, statusMessage: 'Failed to update order' })
+    }
+}
+
+export async function deleteOrder(uuid: string, requesterUuid: string): Promise<void> {
+    const order = await getOrder(uuid)
+    if (!await isRoleHigherOrEqual(order.state_uuid, requesterUuid, RolesInState.MINISTER)) {
+        throw createError({ statusCode: 403, statusMessage: 'Not authorized', data: { statusMessageRu: 'Недостаточно прав для удаления указа' } })
+    }
+    const res = await db().prepare('DELETE FROM state_orders WHERE uuid = ?').run(uuid)
+    if (!res.success) {
+        throw createError({ statusCode: 500, statusMessage: 'Failed to delete order' })
+    }
+}


### PR DESCRIPTION
## Summary
- implement `orders.utils.ts` for state warrants and orders
- add warrant CRUD routes
- add order CRUD routes and finish list route

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684ae94024d48323a99b6464d72ff865